### PR TITLE
Correct release file link in installation docs

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -9,7 +9,7 @@ If you do not have a dokku server for now, please follow [the getting started gu
 :::
 
 ```sh
-wget https://raw.githubusercontent.com/ledokku/ledokku/v0.3.2/ledokku-bootstrap.sh
+wget https://raw.githubusercontent.com/ledokku/ledokku/0.3.2/ledokku-bootstrap.sh
 sudo bash ledokku-bootstrap.sh
 ```
 


### PR DESCRIPTION
Tripped me up on install, seems like 0.3.2 no longer has the `v` on the tag, so the installation doc is wrong. Feel free to disregard this PR if the 0.3.2 tag just has a typo